### PR TITLE
add void-ptr case to ptr->v

### DIFF
--- a/cpsc411-lib/cpsc411/test-suite/utils.rkt
+++ b/cpsc411-lib/cpsc411/test-suite/utils.rkt
@@ -33,7 +33,7 @@
 (define empty-ptr? (curry eq? (current-empty-ptr)))
 (define error-ptr? (ptr? (current-error-tag) (current-error-mask)))
 (define ascii-ptr? (ptr? (current-ascii-char-tag) (current-ascii-char-mask)))
-
+(define void-ptr? (ptr? (current-void-tag) (current-void-mask)))
 (define cons-ptr? (ptr? (current-pair-tag) (current-pair-mask)))
 (define vector-ptr? (ptr? (current-vector-tag) (current-vector-mask)))
 
@@ -46,6 +46,8 @@
      #f]
     [(? fixnum-ptr?)
      (arithmetic-shift v -3)]
+    [(? void-ptr?)
+      (void)]
     [(? empty-ptr?)
      '()]
     [(? error-ptr?)


### PR DESCRIPTION
bug reported in piazza: https://piazza.com/class/mj8yh5nbmhl4ob/post/70

1. add `(void-ptr?)` which checks if a given ptr value is a ptr representation of `'(void)`.
2. add `(? void-ptr?)` case to `ptr->v` which returns `(void)` (in Racket).